### PR TITLE
fixed a bug where d=0 returns nothing

### DIFF
--- a/src/neighbors.h
+++ b/src/neighbors.h
@@ -83,6 +83,7 @@ _neighbors(std::string const& query, TAlphabet const& alphabet, int32_t const in
       if (dist < inputdist) _insert(strset, query);
     }
   }
+  if (inputdist == 0) _insert(strset, query);
 }
       
 


### PR DESCRIPTION
There was a bug that would cause no results to be returned when the `-d` flag was set to zero. This PR fixes the bug.

Before:

```
dicey hunt -d 0 -g GhirsutumCoker_698_v1.0.fa.gz  CACTGTATCATCAGGTAAGATTGTCCAATCTACGAC | python ./dicey/scripts/json2txt.py 
# nothing
```

Now:
```
dicey hunt -d 0 -g GhirsutumCoker_698_v1.0.fa.gz  CACTGTATCATCAGGTAAGATTGTCCAATCTACGAC | python ./dicey/scripts/json2txt.py 
#
# >D08:8153512-8153547 (Strand: +, Distance: 0)
# CACTGTATCATCAGGTAAGATTGTCCAATCTACGAC
# CACTGTATCATCAGGTAAGATTGTCCAATCTACGAC
# 
```